### PR TITLE
hide libgbm_mesa_wrapper when libgbm_mesa is not built

### DIFF
--- a/gbm_mesa_driver/Android.mk
+++ b/gbm_mesa_driver/Android.mk
@@ -18,6 +18,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
+ifneq ($(filter true, $(BOARD_MESA3D_BUILD_LIBGBM)),)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := \
@@ -33,3 +34,4 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_VENDOR_MODULE := true
 
 include $(BUILD_SHARED_LIBRARY)
+endif


### PR DESCRIPTION
for TARGET_USE_MESA=false builds

along with https://github.com/waydroid/android_hardware_waydroid/pull/41